### PR TITLE
Make design implementation independent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 CFLAGS=-Wall -Wextra -Werror -std=c11 -pedantic -ggdb
 
-heap: main.c heap.c heap.h
-	$(CC) $(CFLAGS) -o heap main.c heap.c
+heap: main.c heap_using_chunk_lists.c heap.h
+	$(CC) $(CFLAGS) -o heap main.c heap_using_chunk_lists.c

--- a/chunk_lists.h
+++ b/chunk_lists.h
@@ -1,0 +1,37 @@
+#ifndef CHUNK_LISTS_H_
+#define CHUNK_LISTS_H_
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define UNIMPLEMENTED \
+    do { \
+        fprintf(stderr, "%s:%d: %s is not implemented yet\n", \
+                __FILE__, __LINE__, __func__); \
+        abort(); \
+    } while(0)
+
+#define CHUNK_LIST_CAP 1024
+
+typedef struct {
+    uintptr_t *start;
+    size_t size;
+} Chunk;
+
+typedef struct {
+    size_t count;
+    Chunk chunks[CHUNK_LIST_CAP];
+} Chunk_List;
+
+extern Chunk_List alloced_chunks;
+extern Chunk_List freed_chunks;
+extern Chunk_List tmp_chunks;
+
+void chunk_list_insert(Chunk_List *list, void *start, size_t size);
+void chunk_list_merge(Chunk_List *dst, const Chunk_List *src);
+void chunk_list_dump(const Chunk_List *list, const char *name);
+int chunk_list_find(const Chunk_List *list, uintptr_t *ptr);
+void chunk_list_remove(Chunk_List *list, size_t index);
+
+#endif //CHUNK_LISTS_H_

--- a/heap.h
+++ b/heap.h
@@ -5,13 +5,6 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#define UNIMPLEMENTED \
-    do { \
-        fprintf(stderr, "%s:%d: %s is not implemented yet\n", \
-                __FILE__, __LINE__, __func__); \
-        abort(); \
-    } while(0)
-
 #define HEAP_CAP_BYTES 640000
 static_assert(HEAP_CAP_BYTES % sizeof(uintptr_t) == 0,
               "The heap capacity is not divisible by "
@@ -24,27 +17,5 @@ extern const uintptr_t *stack_base;
 void *heap_alloc(size_t size_bytes);
 void heap_free(void *ptr);
 void heap_collect();
-
-#define CHUNK_LIST_CAP 1024
-
-typedef struct {
-    uintptr_t *start;
-    size_t size;
-} Chunk;
-
-typedef struct {
-    size_t count;
-    Chunk chunks[CHUNK_LIST_CAP];
-} Chunk_List;
-
-extern Chunk_List alloced_chunks;
-extern Chunk_List freed_chunks;
-extern Chunk_List tmp_chunks;
-
-void chunk_list_insert(Chunk_List *list, void *start, size_t size);
-void chunk_list_merge(Chunk_List *dst, const Chunk_List *src);
-void chunk_list_dump(const Chunk_List *list, const char *name);
-int chunk_list_find(const Chunk_List *list, uintptr_t *ptr);
-void chunk_list_remove(Chunk_List *list, size_t index);
 
 #endif // HEAP_H_

--- a/heap_using_chunk_lists.c
+++ b/heap_using_chunk_lists.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include "./heap.h"
+#include "./chunk_lists.h"
 
 uintptr_t heap[HEAP_CAP_WORDS] = {0};
 const uintptr_t *stack_base = 0;

--- a/main.c
+++ b/main.c
@@ -5,6 +5,7 @@
 #include <stdint.h>
 
 #include "./heap.h"
+#include "./chunk_lists.h"
 
 #define JIM_IMPLEMENTATION
 #include "jim.h"


### PR DESCRIPTION
Hi (Privet). 

I watched your youtube video, which is very interesting. 
Would want to try to implement the heap allocation management using linked list or tree. For this raising this PR to have main heap.h header file and then other implementation specific files. 

This would allow anyone to add other implementations of the heap.h. 

Please feel free to comment, and I would make the amendments. 

Thanks in advance,
Mehdi